### PR TITLE
Implement https://github.com/dcmeglio/hubitat-bond/issues/13.

### DIFF
--- a/apps/BOND_Home_Integration.groovy
+++ b/apps/BOND_Home_Integration.groovy
@@ -6,6 +6,7 @@
  *  Copyright 2019-2020 Dominick Meglio
  *
  * Revision History
+ * 2020.01.18 - Added setPosition support for motorized shades, mapping a special value of 50 to the Preset command
  * 2019.12.01 - Fixed an issue where dimmers wouldn't work with fans that support direction controls, fixed an issue setting flame height
  * 2019.11.24 - Added support for timer based fan light dimmers and flame height adjustment for fireplaces
  * 2019.12.14 - Added support for Switch capability to the motorized shades for compatibility
@@ -916,6 +917,14 @@ def handleStop(device)
 	logDebug "Handling Stop event for ${bondId}"
 	
     executeAction(bondId, "Hold")
+}
+
+def handlePreset(device)
+{
+	def bondId = getBondIdFromDevice(device)
+	logDebug "Handling Preset event for ${bondId}"
+	
+    executeAction(bondId, "Preset")
 }
 
 def fixPowerState(device, state) 

--- a/drivers/BOND_Motorized_Shade.groovy
+++ b/drivers/BOND_Motorized_Shade.groovy
@@ -53,3 +53,17 @@ def fixShade(shade) {
 	parent.fixShadeState(device, shade)
 }
 
+def setPosition(Number position) {
+    if (position == 0) {
+        log.info "position special value 0 is set, trigger CLose command"
+        close()
+    } else if (position == 50) {
+        log.info "position special value 50 is set, triggering Preset command"
+        parent.handlePreset(device)
+    } else if (position == 100) {
+        log.info "position special value 100 is set, triggering Open command"
+        open()
+    } else {
+        log.info "no-op for position value " + position + ", set position to 50 to trigger Preset command"
+    }
+}

--- a/packageManifest.json
+++ b/packageManifest.json
@@ -2,11 +2,11 @@
 	"packageName": "BOND Home Integration",
 	"minimumHEVersion": "2.1.9",
 	"author": "Dominick Meglio",
-	"version": "1.3.4",
-	"dateReleased": "2020-09-01",
+	"version": "1.4.0",
+	"dateReleased": "2021-01-25",
 	"documentationLink": "https://github.com/dcmeglio/hubitat-bond/blob/master/README.md",
 	"communityLink": "https://community.hubitat.com/t/support-for-bond-hub/19141",
-	"releaseNotes": "Fixed an issue that prevented the direction command from working.",
+	"releaseNotes": "Added support for the Preset command for shades including a setPosition command that supports 0/50/100 as values.",
 	"apps" : [
 		{
 			"id" : "bf7d70fb-1fa9-436f-9cfc-fb8520cda22a",


### PR DESCRIPTION
This change adds support for calling the Bond Preset command for motorized shades and maps a special setPosition value of "50" to the Preset command. Hardcoding a special value of "50" is a simplification of a similar pattern used for the Hubitat Somfy Z-Wave controller where a user configurable special setPosition value can be mapped to the Somfy My Button preset value, see https://github.com/dennypage/hubitat/tree/master/drivers/zrtsii.